### PR TITLE
Verify merge On chain

### DIFF
--- a/contracts/Misc/ProofOfMerge.sol
+++ b/contracts/Misc/ProofOfMerge.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+/// @title Merge verify onChain
+/// @author supernovahs.eth <supernovahs@proton.me>
+/// @dev Verifies that Ethereum switched to Proof of stake using the difficulty opcode . 
+/// For more info  Refer  https://eips.ethereum.org/EIPS/eip-4399#reusing-the-difficulty-opcode-instead-of-introducing-a-new-one 
+contract VerifyMerge{
+
+/// Checks difficulty of current block
+/// return bool -> Merge is successfull  ? true  : false
+    function Merge() public view returns (bool){
+        return (block.difficulty ==0 || block.difficulty > 2**64);
+    }
+
+}


### PR DESCRIPTION
## Description

This contract verifies on chain whether Merge was successful  or not . This is achieved by using the difficulty opcode . 
https://eips.ethereum.org/EIPS/eip-4399#reusing-the-difficulty-opcode-instead-of-introducing-a-new-one
 <br />

Fixes  [#80](https://github.com/metafy-social/web3-smart-contracts/issues/80)

