### PR TITLE
Added modifier to remove duplication

### DIFF
--- a/contracts/Banking/BankingSystem.sol
+++ b/contracts/Banking/BankingSystem.sol
@@ -2,24 +2,26 @@
 pragma solidity ^0.8.0;
 
 contract BankingSystem {
-
     mapping(address => uint256) public balanceOf;   // balanceOf, indexed by addresses
+
+    // This is the modifier that will check if the caller has sufficient funds
+    modifier hasSufficientFunds(uint _amount) {
+        require (balanceOf[msg.sender] >= _amount, "Insufficient Funds");
+        _;
+    }
 
     function deposit() public payable {
         balanceOf[msg.sender] += msg.value;
     }
 
-    function withdraw(uint _amount) public {
-        require (balanceOf[msg.sender] >= _amount, "Insufficent Funds");
+    function withdraw(uint _amount) public hasSufficientFunds(_amount) {
         balanceOf[msg.sender] -= _amount;
         (bool sent,) = msg.sender.call{value: _amount}("Sent");
         require(sent, "Failed to Complete");
     }
 
     // transferAmt function transfers ether from one account to another
-    function transferAmt(address payable _address, uint _amount) public {
-        require (balanceOf[msg.sender] >= _amount, "Insufficent Funds");
+    function transferAmt(address payable _address, uint _amount) public hasSufficientFunds(_amount) {
         _address.transfer(_amount);
     }
-
 }


### PR DESCRIPTION
## Description

the hasSufficientFunds modifier is defined at the top of the contract. This modifier checks if the caller has sufficient funds to perform the requested operation, and if not, it will throw an error.

The withdraw and transferAmt functions both use the hasSufficientFunds modifier, which means that they will both check if the caller has sufficient funds before executing any other code in the function. This avoids repeating the same code in multiple places.

<br />

Fixes #144 






## Screenshots of relevant screens

<img width="1470" alt="Screenshot 2022-12-15 at 11 09 10 PM" src="https://user-images.githubusercontent.com/37846481/207930135-e1f028ff-e61a-46a7-8067-8787f5b0c90a.png">

## Developer's checklist

- [X]  My PR follows the style guidelines of this project
- [X] I have performed a self-check 




**If changes are made in the code:**

- [X] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [X] My changes in code generate no new warnings
- [X] I have added relevant screenshots in my PR
